### PR TITLE
Fix problems sending non-ASCII data to HaloPSA

### DIFF
--- a/Private/Invoke-HaloRequest.ps1
+++ b/Private/Invoke-HaloRequest.ps1
@@ -40,7 +40,7 @@ function Invoke-HaloRequest {
     }
     try {
         Write-Verbose "Making a $($WebRequestParams.Method) request to $($WebRequestParams.Uri)"
-        $Response = Invoke-WebRequest @WebRequestParams -Headers $AuthHeaders -ContentType 'application/json'
+        $Response = Invoke-WebRequest @WebRequestParams -Headers $AuthHeaders -ContentType 'application/json; charset=utf-8'
         Write-Debug "Response headers: $($Response.Headers | Out-String)"
         if ($RawResult) {
             $Results = $Response


### PR DESCRIPTION
Non-ASCII cannot be sent to HaloPSA. This pullr request should fix that.

Example on request that's not working without this fix:

```
Set-HaloAsset -Asset @{id=339; notes='æøå'}
```