### PR TITLE
Added the parameter to include prepay history for Get-HaloClient

### DIFF
--- a/Public/Get/Get-HaloClient.ps1
+++ b/Public/Get/Get-HaloClient.ps1
@@ -57,7 +57,10 @@ function Get-HaloClient {
         [Switch]$IncludeDetails,
         # Include ticket activity in the result.
         [Parameter( ParameterSetName = 'Single' )]
-        [Switch]$IncludeActivity
+        [Switch]$IncludeActivity,
+        # Include prepay objects in the result.
+        [Parameter( ParameterSetName = 'Single' )]
+        [Switch]$IncludePrepay
     )
     Invoke-HaloPreFlightCheck
     $CommandName = $MyInvocation.InvocationName
@@ -76,27 +79,27 @@ function Get-HaloClient {
             $QSCollection = New-HaloQuery -CommandName $CommandName -Parameters $Parameters
             $Resource = "api/client/$($ClientID)"
             $RequestParams = @{
-                Method = 'GET'
-                Resource = $Resource
+                Method          = 'GET'
+                Resource        = $Resource
                 AutoPaginateOff = $True
-                QSCollection = $QSCollection
-                ResourceType = 'clients'
+                QSCollection    = $QSCollection
+                ResourceType    = 'clients'
             }
         } else {
             Write-Verbose 'Running in multi-client mode.'
             $QSCollection = New-HaloQuery -CommandName $CommandName -Parameters $Parameters -IsMulti
             $Resource = 'api/client'
             $RequestParams = @{
-                Method = 'GET'
-                Resource = $Resource
+                Method          = 'GET'
+                Resource        = $Resource
                 AutoPaginateOff = $Paginate
-                QSCollection = $QSCollection
-                ResourceType = 'clients'
+                QSCollection    = $QSCollection
+                ResourceType    = 'clients'
             }
         }
         $ClientResults = New-HaloGETRequest @RequestParams
         if ($FullObjects) {
-            $AllClientResults = $ClientResults | ForEach-Object {             
+            $AllClientResults = $ClientResults | ForEach-Object {
                 Get-HaloClient -ClientID $_.id
             }
             $ClientResults = $AllClientResults


### PR DESCRIPTION
Added a parameter (-IncludePrepay) to the Get-HaloClient function to include prepay object(s) in the client object that is returned.