### PR TITLE
Refactor: Append base URL to URI if not provided in Invoke-HaloRequest.ps1

### DIFF
--- a/Public/Invoke/Invoke-HaloRequest.ps1
+++ b/Public/Invoke/Invoke-HaloRequest.ps1
@@ -47,7 +47,7 @@ function Invoke-HaloRequest {
     $BaseDelay = 5 # Base delay of 5 seconds
     $MaxDelay = 60 # Maximum delay of 60 seconds
     # Check if $WebRequestParams contains a full URI, if not, append the base URL
-    if ($WebRequestParams.Uri -notlike 'http*') {
+    if (-not ([System.Uri]$WebRequestParams.Uri).IsAbsoluteUri) {
         $WebRequestParams.Uri = $Script:HAPIConnectionInformation.URL + $WebRequestParams.Uri
     }
     do {

--- a/Public/Invoke/Invoke-HaloRequest.ps1
+++ b/Public/Invoke/Invoke-HaloRequest.ps1
@@ -46,6 +46,10 @@ function Invoke-HaloRequest {
     $Retries = 0
     $BaseDelay = 5 # Base delay of 5 seconds
     $MaxDelay = 60 # Maximum delay of 60 seconds
+    # Check if $WebRequestParams contains a full URI, if not, append the base URL
+    if ($WebRequestParams.Uri -notlike 'http*') {
+        $WebRequestParams.Uri = $Script:HAPIConnectionInformation.URL + $WebRequestParams.Uri
+    }
     do {
         $Retries++
         Write-Verbose "Attempt $Retries of 10"


### PR DESCRIPTION
This pull request refactors the `Invoke-HaloRequest` function in `Invoke-HaloRequest.ps1` to append the base URL to the URI if it is not already provided. This ensures that the correct URL is used for the request.