### PR TITLE
Update CustomTable to be able to retrieve single custom table.

### DIFF
--- a/Public/Get/Get-HaloCustomTable.ps1
+++ b/Public/Get/Get-HaloCustomTable.ps1
@@ -25,7 +25,7 @@ function Get-HaloCustomTable {
     }
     $QSCollection = New-HaloQuery -CommandName $CommandName -Parameters $Parameters
     try {
-        if ($AgentID) {
+        if ($CustomTableId) {
             Write-Verbose "Running in single-custom table mode because '-CustomTableId' was provided."
             $Resource = "api/customtable/$($CustomTableId)"
         } else {

--- a/Tests/EndToEnd/CustomTable.E2E.Tests.ps1
+++ b/Tests/EndToEnd/CustomTable.E2E.Tests.ps1
@@ -37,9 +37,9 @@ Describe 'CustomTable' {
     }
     Context 'Get Single' {
         It 'succeeds to get a specific custom table.' {
-            $CustomTableResult = Get-HaloCustomTable -CustomTableId 1005
+            $CustomTableResult = Get-HaloCustomTable -CustomTableId $CurrentCustomTableId
             $CustomTableResult.Count | Should -Be 1
-            $CustomTableResult.id | Should -Be 1005
+            $CustomTableResult.id | Should -Be $CurrentCustomTableId
         }
         It 'fails to get a non existent custom table' {
             $CustomTableId = 50

--- a/Tests/EndToEnd/CustomTable.E2E.Tests.ps1
+++ b/Tests/EndToEnd/CustomTable.E2E.Tests.ps1
@@ -1,0 +1,49 @@
+<#
+    .SYNOPSIS
+        E2E custom table entity test suite for the HaloAPI module.
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'Test file - parameters are used in separate scopes.')]
+param()
+
+BeforeAll {
+    $ModulePath = Split-Path -Parent -Path (Split-Path -Parent -Path (Split-Path -Parent -Path $PSCommandPath))
+    $ModuleName = 'HaloAPI'
+    $ManifestPath = "$($ModulePath)\$($ModuleName).psd1"
+    if (Get-Module -Name $ModuleName) {
+        Remove-Module $ModuleName -Force
+    }
+    Import-Module $ManifestPath -Verbose:$False
+    $HaloConnectionParameters = @{
+        URL = $env:HaloTestingURL
+        ClientID = $env:HaloTestingClientID
+        ClientSecret = $env:HaloTestingClientSecret
+        Scopes = 'all'
+        Tenant = $env:HaloTestingTenant
+    }
+    Connect-HaloAPI @HaloConnectionParameters *> $null
+}
+
+#TODO: This will also need tests for create.
+# Test that we can fetch a custom table.
+Describe 'CustomTable' {
+    BeforeEach {
+        $CurrentCustomTableId = (Get-HaloCustomTable | Select-Object -First 1 | Select-Object -ExpandProperty ID)
+    }
+    Context 'Get All' {
+        It 'succeeds to get multiple custom tables.' {
+            $CustomTableResult = Get-HaloCustomTable
+            $CustomTableResult.Count | Should -BeGreaterThan 1
+        }
+    }
+    Context 'Get Single' {
+        It 'succeeds to get a specific custom table.' {
+            $CustomTableResult = Get-HaloCustomTable -CustomTableId 1005
+            $CustomTableResult.Count | Should -Be 1
+            $CustomTableResult.id | Should -Be 1005
+        }
+        It 'fails to get a non existent custom table' {
+            $CustomTableId = 999
+            { Get-HaloCustomTable -CustomTableId $CustomTableId } | Should -Throw -ExceptionType 'System.Exception' -ExpectedMessage 'Response status code does not indicate success: 404 (Not Found).'
+        }
+    }
+}

--- a/Tests/EndToEnd/CustomTable.E2E.Tests.ps1
+++ b/Tests/EndToEnd/CustomTable.E2E.Tests.ps1
@@ -42,7 +42,7 @@ Describe 'CustomTable' {
             $CustomTableResult.id | Should -Be 1005
         }
         It 'fails to get a non existent custom table' {
-            $CustomTableId = 999
+            $CustomTableId = 50
             { Get-HaloCustomTable -CustomTableId $CustomTableId } | Should -Throw -ExceptionType 'System.Exception' -ExpectedMessage 'Response status code does not indicate success: 404 (Not Found).'
         }
     }


### PR DESCRIPTION
When using the Get-HaloCustomTable function with the CustomTableID parameter I was getting all custom tables back in the response.

I first created an E2E test in the same style as your existing Action and Agent E2E tests to confirm the issue. This test will need additional tests for the create functionality but I specifically just did the fetch functionality as that was where I was seeing the issue. Also, the IDs used in the test are from my test environment and if these tests are ran in any pipeline that you have you will likely need to update the IDs to appropriate values for your test environment.

Actual change to the code itself was just one variable check. It looks like it may have initially been copied from Get-HaloAgent and so had a check against AgentID. This was updated to CustomTableID. Tests then passed.