### PR TITLE
Fixes Get-HaloAsset to use Command Separated IDs

### DIFF
--- a/Public/Get/Get-HaloAsset.ps1
+++ b/Public/Get/Get-HaloAsset.ps1
@@ -252,7 +252,7 @@ function Get-HaloAsset {
     try {
         if ($AssetID) {
             Write-Verbose "Running in single-asset mode because '-AssetID' was provided."
-            $QSCollection = New-HaloQuery -CommandName $CommandName -Parameters $Parameters
+            $QSCollection = New-HaloQuery -CommandName $CommandName -Parameters $Parameters -CommaSeparatedArrays
             $Resource = "api/asset/$($AssetID)"
             $RequestParams = @{
                 Method          = 'GET'
@@ -263,7 +263,7 @@ function Get-HaloAsset {
             }
         } else {
             Write-Verbose 'Running in multi-asset mode.'
-            $QSCollection = New-HaloQuery -CommandName $CommandName -Parameters $Parameters -IsMulti
+            $QSCollection = New-HaloQuery -CommandName $CommandName -Parameters $Parameters -IsMulti -CommaSeparatedArrays
             $Resource = 'api/asset'
             $RequestParams = @{
                 Method          = 'GET'


### PR DESCRIPTION
Halo API documentation has comma separated ids listed for all query string parameters where you might want multiple values for the `/Asset` endpoint.

Added the `-CommaSeparatedArrays` switch to the cmdlet after testing (quickly) myself.

Without this, attempting to use the `-AssetTypes` and `-AssetGroupTypes` (and possibly others) fails to build the parameters:

```
Exception calling "Add" with "2" argument(s): "Item has already been added. Key in dictionary: 'assettypes'  Key being added: 'assettypes'"
```