### PR TITLE
Enhance cSpell configuration and update documentation badges

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -33,8 +33,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        startsWith(github.event.workflow_run.head_branch, 'v')
+        github.event.workflow_run.event == 'push'
       )
     steps:
       - name: Checkout HaloAPI repository

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "Analyzer",
     "authinfo",
     "cmdletbinding",
+    "Color",
     "commandlets",
     "distributionlist",
     "distributionlistid",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,18 @@
 {
   "cSpell.words": [
+    "Analyzer",
     "authinfo",
     "cmdletbinding",
+    "commandlets",
     "distributionlist",
     "distributionlistid",
     "distributionlists",
+    "haloapi",
+    "Homotechsual",
+    "homotechsualdocs",
+    "ITSM",
     "pageinate",
+    "pssa",
     "PWSH",
     "Testand"
   ],

--- a/Docs/HaloAPI/index.mdx
+++ b/Docs/HaloAPI/index.mdx
@@ -8,8 +8,9 @@ sidebar_position: 0
 [![HaloPSA Community Discord](https://img.shields.io/discord/1044558967545806940?style=for-the-badge&logo=discord&logoColor=white&label=HaloPSA%20Community%20Discord)](https://discord.halopsa.community)
 [![HaloITSM Admin Hangout Discord](https://img.shields.io/discord/1050832376185495562?style=for-the-badge&logo=discord&logoColor=white&label=HaloITSM%20Admin%20Hangout%20Discord)](https://discord.gg/vy53fYdPkW)
 [![GitHub contributors](https://img.shields.io/github/contributors/homotechsual/haloapi?style=for-the-badge&logo=github)](https://github.com/homotechsual/haloapi/)
-[![Azure DevOps Pipeline Status](https://img.shields.io/azure-devops/tests/MSPsUK/HaloAPI/4?style=for-the-badge)](https://dev.azure.com/MSPsUK/HaloAPI/_build?definitionId=4)
-[![Azure DevOps Code Coverage](https://img.shields.io/azure-devops/coverage/MSPsUK/HaloAPI/4?style=for-the-badge)](https://dev.azure.com/MSPsUK/HaloAPI/_build?definitionId=4)
+[![CI](https://img.shields.io/github/actions/workflow/status/homotechsual/HaloAPI/ci.yml?style=for-the-badge&label=CI)](https://github.com/homotechsual/HaloAPI/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/actions/workflow/status/homotechsual/HaloAPI/release.yml?style=for-the-badge&label=Release)](https://github.com/homotechsual/HaloAPI/actions/workflows/release.yml)
+[![Code Coverage](https://img.shields.io/badge/Code%20Coverage-Meta%20%26%20Unit-blue?style=for-the-badge)](https://github.com/homotechsual/HaloAPI/actions/workflows/ci.yml)
 [![PowerShell Gallery](https://img.shields.io/powershellgallery/dt/HaloAPI?style=for-the-badge)](https://www.powershellgallery.com/packages/HaloAPI/)
 [![License](https://img.shields.io/github/license/homotechsual/HaloAPI?style=for-the-badge)](https://mit.license.homotechsual.dev)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/homotechsual?style=for-the-badge)](https://github.com/sponsors/homotechsual/)
@@ -19,6 +20,19 @@ sidebar_position: 0
 ## About
 
 This module provides a PowerShell interface to the Halo API. It's designed to for PowerShell developers to build their own PowerShell scripts and modules to interact with Halo. It's well tested for Halo Professional Services Automation (PSA) but should work with Halo IT Service Management (ITSM), Halo Service Desk and Halo Customer Relationship Management (CRM).
+
+## Code Coverage
+
+Code coverage is generated in CI for the `Meta` and `Unit` suites.
+
+Coverage artifacts are uploaded for each run as:
+
+* `code-coverage-meta-results` (`.artifacts/CodeCoverage.meta.xml`)
+* `code-coverage-unit-results` (`.artifacts/CodeCoverage.unit.xml`)
+
+You can access them from the CI workflow runs:
+
+[GitHub Actions CI workflow](https://github.com/homotechsual/HaloAPI/actions/workflows/ci.yml)
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/homotechsual?style=for-the-badge)](https://github.com/sponsors/homotechsual/)
 [![Stable Release](https://img.shields.io/powershellgallery/v/HaloAPI?label=Stable+Release&style=for-the-badge)](https://www.powershellgallery.com/packages/HaloAPI/)
 [![Preview Release](https://img.shields.io/powershellgallery/v/HaloAPI?label=Preview+Release&include_prereleases&style=for-the-badge)](https://www.powershellgallery.com/packages/HaloAPI/)
+[![Code Coverage](https://img.shields.io/badge/Code%20Coverage-Meta%20%26%20Unit-blue?style=for-the-badge)](https://github.com/homotechsual/HaloAPI/actions/workflows/ci.yml)
 
 ## Who are we?
 
@@ -29,6 +30,19 @@ HaloAPI provides a PowerShell wrapper around the Halo API, tested extensively ag
 ## Where's the content?
 
 Use the docs website for the most up-to-date generated command reference and development guidance. The docs publishing workflows sync HaloAPI content into the shared `homotechsualdocs` site structure.
+
+## Code Coverage
+
+Code coverage is collected in CI for the `Meta` and `Unit` suites using the standard test entrypoint in `DevOps/Quality/test.ps1`.
+
+Coverage artifacts are published on every CI run as:
+
+* `code-coverage-meta-results` (`.artifacts/CodeCoverage.meta.xml`)
+* `code-coverage-unit-results` (`.artifacts/CodeCoverage.unit.xml`)
+
+View the latest run artifacts from the CI workflow:
+
+<https://github.com/homotechsual/HaloAPI/actions/workflows/ci.yml>
 
 ## Installing
 


### PR DESCRIPTION
This pull request updates documentation and configuration files to improve clarity around code coverage reporting, modernize status badges, and enhance spelling support in the development environment. The most notable changes are the addition of code coverage information to both the documentation and README, updates to badge links to reflect the current CI/CD setup, and a minor adjustment to a workflow trigger.

**Documentation and README improvements:**

* Added a new "Code Coverage" section to both `Docs/HaloAPI/index.mdx` and `README.md`, explaining how code coverage is collected in CI for the `Meta` and `Unit` test suites and how to access the resulting artifacts. [[1]](diffhunk://#diff-b3f264e673efcdd0d957c3b273df2879b4d958b90e13782b9a143e0c5b3137fdR24-R36) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34-R46)
* Added a code coverage badge to the top of both the documentation and README to provide quick access to coverage status. [[1]](diffhunk://#diff-b3f264e673efcdd0d957c3b273df2879b4d958b90e13782b9a143e0c5b3137fdL11-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10)

**CI/CD and badge updates:**

* Replaced Azure DevOps pipeline and coverage badges in `Docs/HaloAPI/index.mdx` with GitHub Actions badges for CI and release workflows, and updated the code coverage badge to match the new reporting.

**Development environment:**

* Expanded the list of recognized words in `.vscode/settings.json` to improve spell checking for project-specific terminology.

**Workflow configuration:**

* Slightly relaxed the condition for publishing docs in `.github/workflows/publish-docs.yml` by removing the requirement that the branch name starts with 'v' for workflow_run events.