### PR TITLE
Fix parallel batch item invocation in Invoke-HaloBatchProcessor

### DIFF
--- a/Private/Invoke-HaloBatchProcessor.ps1
+++ b/Private/Invoke-HaloBatchProcessor.ps1
@@ -108,7 +108,19 @@ function Invoke-HaloBatchProcessor {
         $_ | ForEach-Object -Parallel {
             Import-Module $Using:ModulePath
             $LocalBatchResults = $using:BatchResults
-            $Result = Invoke-HaloBatchItem -BatchItem $_ -EntityType $Using:EntityType -CommandName $Using:CommandName -CommandExists ([bool]$Using:CommandExists) -Parameters $Using:Parameters -ConnectionInformation $Using:HAPIConnectionInformation
+            $HaloModule = Get-Module -Name 'HaloAPI'
+            $Result = $HaloModule.Invoke({
+                    param(
+                        [Object]$BatchItem,
+                        [String]$EntityType,
+                        [String]$CommandName,
+                        [Boolean]$CommandExists,
+                        [Object]$Parameters,
+                        [Object]$ConnectionInformation
+                    )
+
+                    Invoke-HaloBatchItem -BatchItem $BatchItem -EntityType $EntityType -CommandName $CommandName -CommandExists $CommandExists -Parameters $Parameters -ConnectionInformation $ConnectionInformation
+                }, @($_, $Using:EntityType, $Using:CommandName, ([bool]$Using:CommandExists), $Using:Parameters, $Using:HAPIConnectionInformation))
             if ($null -ne $Result) {
                 $LocalBatchResults.Add($Result)
             }
@@ -118,5 +130,5 @@ function Invoke-HaloBatchProcessor {
             Start-Sleep -Seconds $Wait
         }
     }
-    Return $BatchResults
+    return $BatchResults.ToArray()
 }


### PR DESCRIPTION
This pull request updates the `Invoke-HaloBatchProcessor` function to improve how batch item processing is executed in parallel and how results are returned. The main changes involve invoking batch items within the context of the `HaloAPI` module and returning batch results as an array.

**Parallel Processing and Results Handling:**

* Batch item invocation is now performed via the `HaloAPI` module's `Invoke` method, ensuring that the execution context and dependencies are correctly managed when running in parallel.
* The function now returns the batch results as an array using `.ToArray()`, which standardizes the output format and may improve compatibility with downstream processing.