### PR TITLE
Update version to 1.23.2 and document batch processor fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 If you contributed one of these and there's no credit in the line PR to add it or let me know!
 
+## 2026-04-29 - Version 1.23.2
+
+* Fix `Invoke-HaloBatchProcessor` parallel runspace error where `Invoke-HaloBatchItem` was not recognised; private function is now invoked via `Module.Invoke()` within the imported module scope.
+
 ## 2026-04-29 - Version 1.23.1
 
 * Fix `Get-HaloTicket` pagination behavior so explicitly providing `-PageNo` and/or `-PageSize` no longer auto-fetches all pages.

--- a/HaloAPI.psd1
+++ b/HaloAPI.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\HaloAPI.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.23.1'
+    ModuleVersion = '1.23.2'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')


### PR DESCRIPTION
This pull request releases version 1.23.2 of the module and addresses a bug related to parallel execution in the `Invoke-HaloBatchProcessor` function.

Release and bug fix:

* Updated module version to 1.23.2 in `HaloAPI.psd1` and added a corresponding changelog entry. [[1]](diffhunk://#diff-2777d45ffa71199d526b654e6524e71b85f753979f5366026eb4ee426ccc3434L15-R15) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R8)
* Fixed an issue where `Invoke-HaloBatchProcessor` failed to recognize the private function `Invoke-HaloBatchItem` during parallel runspace execution by ensuring it is invoked via `Module.Invoke()` within the imported module scope.