### PR TITLE
Fix release title to match tag name and improve build output

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -73,7 +73,7 @@ jobs:
           }
 
           if ((Test-Path -Path $notesPath) -and -not [string]::IsNullOrWhiteSpace((Get-Content -Path $notesPath -Raw))) {
-            gh release create $tagName @preReleaseFlag --notes-file $notesPath
+            gh release create $tagName @preReleaseFlag --title $tagName --notes-file $notesPath
           } else {
-            gh release create $tagName @preReleaseFlag --generate-notes
+            gh release create $tagName @preReleaseFlag --title $tagName --generate-notes
           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 If you contributed one of these and there's no credit in the line PR to add it or let me know!
 
+## 2026-04-30 - Version 1.23.3
+
+* Fix release packaging layout so `Public`, `Private`, `Classes`, and `Data` remain wrapped as top-level folders in module output.
+* Add meta test coverage to guard against output structure regressions in build packaging.
+
 ## 2026-04-29 - Version 1.23.2
 
 * Fix `Invoke-HaloBatchProcessor` parallel runspace error where `Invoke-HaloBatchItem` was not recognised; private function is now invoked via `Module.Invoke()` within the imported module scope.

--- a/DevOps/Build/build.ps1
+++ b/DevOps/Build/build.ps1
@@ -100,7 +100,8 @@ function Build {
     foreach ($pathToCopy in $pathsToCopy) {
         $sourcePath = Join-Path -Path $RepoRoot -ChildPath $pathToCopy
         if (Test-Path -Path $sourcePath -PathType Container) {
-            Copy-Item -Path (Join-Path -Path $sourcePath -ChildPath '*') -Destination $moduleOutputPath -Recurse -Force
+            # Copy each top-level source folder as a folder to preserve module layout in release output.
+            Copy-Item -Path $sourcePath -Destination $moduleOutputPath -Recurse -Force
         }
     }
 

--- a/HaloAPI.psd1
+++ b/HaloAPI.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\HaloAPI.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.23.2'
+    ModuleVersion = '1.23.3'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')
@@ -316,7 +316,7 @@
             IconUri = 'https://3c3br937rz386088k2z3qqdi-wpengine.netdna-ssl.com/wp-content/uploads/2020/04/HaloIcon-300x300.png'
 
             # ReleaseNotes of this module
-            ReleaseNotes = 'https://github.com/homotechsual/HaloAPI/releases/tag/1.22.1'
+            ReleaseNotes = 'https://github.com/homotechsual/HaloAPI/releases/tag/1.23.3'
 
             # Prerelease string of this module
             # Prerelease = 'Beta1'

--- a/Tests/HaloAPI.Meta.Tests.ps1
+++ b/Tests/HaloAPI.Meta.Tests.ps1
@@ -87,3 +87,22 @@ Describe 'Quality test entrypoint suite parsing' {
         $Script:QualityTestScriptContent | Should -Match '-split\s+''\\s\*,\\s\*'''
     }
 }
+
+Describe 'Build output layout' {
+    BeforeAll {
+        $Script:BuildScriptPath = Join-Path -Path $ModulePath -ChildPath 'DevOps\Build\build.ps1'
+        $Script:BuiltModulePath = Join-Path -Path $ModulePath -ChildPath 'Output\HaloAPI'
+    }
+
+    It 'preserves wrapped top-level folders in packaged output' {
+        {
+            & $Script:BuildScriptPath -TaskNames @('clean', 'build')
+        } | Should -Not -Throw
+
+        $expectedDirectories = @('Public', 'Private', 'Classes', 'Data')
+        foreach ($expectedDirectory in $expectedDirectories) {
+            $expectedPath = Join-Path -Path $Script:BuiltModulePath -ChildPath $expectedDirectory
+            Test-Path -Path $expectedPath -PathType Container | Should -BeTrue
+        }
+    }
+}


### PR DESCRIPTION
This pull request focuses on improving the release packaging process to ensure the module output preserves its intended folder structure. It also adds automated test coverage to prevent regressions in the build output layout. Additionally, versioning and release metadata have been updated to reflect these changes.

**Release Packaging Improvements**
* Updated the `Build` function in `DevOps/Build/build.ps1` to copy each top-level source folder (`Public`, `Private`, `Classes`, `Data`) as a folder, preserving the module's layout in the release output.
* Updated the GitHub Actions release workflow in `.github/workflows/create-release.yml` to always set the release title to the tag name when creating a release.

**Test Coverage**
* Added a new test in `Tests/HaloAPI.Meta.Tests.ps1` to verify that the packaged output retains the expected top-level directories, guarding against future regressions in build packaging.

**Versioning and Metadata**
* Bumped the module version to `1.23.3` in `HaloAPI.psd1` and updated the `ReleaseNotes` link accordingly. [[1]](diffhunk://#diff-2777d45ffa71199d526b654e6524e71b85f753979f5366026eb4ee426ccc3434L15-R15) [[2]](diffhunk://#diff-2777d45ffa71199d526b654e6524e71b85f753979f5366026eb4ee426ccc3434L319-R319)
* Added a changelog entry for version `1.23.3` describing the packaging fix and new test coverage.